### PR TITLE
Added signatureVersion to S3 init to support newer regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,12 @@ yield Storage.putFile('path/to/file/directory', contents)
 // File will be stored at `path/to/file/directory/filename`
 yield Storage.putFileAs('path/to/file/directory', contents, filename)
 
+// Additional parameters can be passed to the S3 driver
+yield Storage.putFile('/path/to/file', contents, {ContentType: 'image/jpeg'})
+
 // Return the url or absolute file path for accessing the file
 yield Storage.url('path/to/file')
+
 
 ```
 

--- a/src/Drivers/FileSystem.js
+++ b/src/Drivers/FileSystem.js
@@ -71,7 +71,7 @@ class FileSystem {
   /**
    * Write contents to a file at `path`.
    */
-  put (path, contents) {
+  put (path, contents, driverOpts={}) {
     const fullPath = this._fullPath(path)
     // Create directory if needed
     const pathWithoutFilename = fullPath.slice(0, fullPath.lastIndexOf('/'))

--- a/src/Drivers/S3.js
+++ b/src/Drivers/S3.js
@@ -67,13 +67,13 @@ class S3 {
   /**
    * Write contents to a file at `path`.
    */
-  * put (path, contents) {
+  * put (path, contents, driverOpts={}) {
     return new Promise((resolve, reject) => {
-      this.s3.upload({
+      this.s3.upload(Object.assign({
         Bucket: this.disk.bucket,
         Key: path,
         Body: contents
-      }, (err, data) => {
+      } driverOpts), (err, data) => {
         if (err) return reject(err)
         return resolve(data.Location)
       })

--- a/src/Drivers/S3.js
+++ b/src/Drivers/S3.js
@@ -14,7 +14,8 @@ class S3 {
     this.s3 = new AWS.S3({
       accessKeyId: this.disk.key,
       secretAccessKey: this.disk.secret,
-      region: this.disk.region
+      region: this.disk.region,
+      signatureVersion: 'v4',
     })
   }
 

--- a/src/Drivers/S3.js
+++ b/src/Drivers/S3.js
@@ -73,7 +73,7 @@ class S3 {
         Bucket: this.disk.bucket,
         Key: path,
         Body: contents
-      } driverOpts), (err, data) => {
+      }, driverOpts), (err, data) => {
         if (err) return reject(err)
         return resolve(data.Location)
       })

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -49,6 +49,7 @@ class Storage {
    * @param  string  $path
    * @param  string|resource  $contents
    * @param  string  $visibility
+   * @param  object  driveroptions
    * @return bool
    */
   * put (path, contents, driverOpts={}) {
@@ -63,6 +64,7 @@ class Storage {
    *
    * @param  string  path
    * @param  {File}  file
+   * @param  object  driveroptions
    * @return string|false
    */
   * putFile (path, file, driverOpts={}) {
@@ -76,6 +78,7 @@ class Storage {
    * @param  string  path
    * @param  {File} file
    * @param  string  name
+   * @param  object  driveroptions
    * @return string|false
    */
   * putFileAs (filePath, file, name, driverOpts={}) {

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -51,11 +51,11 @@ class Storage {
    * @param  string  $visibility
    * @return bool
    */
-  * put (path, contents) {
+  * put (path, contents, driverOpts={}) {
     if (contents instanceof File) {
       return yield this.putFile(path, contents)
     }
-    return yield this.driver.put(path, contents)
+    return yield this.driver.put(path, contents, driverOpts)
   }
 
   /**
@@ -65,9 +65,9 @@ class Storage {
    * @param  {File}  file
    * @return string|false
    */
-  * putFile (path, file) {
+  * putFile (path, file, driverOpts={}) {
     const fileHash = yield md5File(file.file.path)
-    return yield this.putFileAs(path, file, fileHash)
+    return yield this.putFileAs(path, file, fileHash, driverOpts)
   }
 
   /**
@@ -78,9 +78,9 @@ class Storage {
    * @param  string  name
    * @return string|false
    */
-  * putFileAs (filePath, file, name) {
+  * putFileAs (filePath, file, name, driverOpts={}) {
     const stream = fs.createReadStream(file.file.path)
-    return yield this.put(path.join(filePath, name), stream)
+    return yield this.put(path.join(filePath, name), stream, driverOpts)
   }
 
   /**


### PR DESCRIPTION
Only older regions support the older V3 signing, which leads to the following error when trying to upload a file;

`The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256`

V4 should be supported everywhere. 